### PR TITLE
OPS-369

### DIFF
--- a/ssh-ssm.sh
+++ b/ssh-ssm.sh
@@ -26,7 +26,8 @@ function cleanup {
 function tempkey {
   set -o errexit
   trap cleanup EXIT
-  ssh-keygen -t ed25519 -N '' -f "${ssh_local}"/ssm-ssh-tmp -C ssm-ssh-session
+#  ssh-keygen -t ed25519 -N '' -f "${ssh_local}"/ssm-ssh-tmp -C ssm-ssh-session
+  ssh-keygen -t rsa -b 4096 -N '' -f "${ssh_local}"/ssm-ssh-tmp -C ssm-ssh-session
   ssh_pubkey=$(< "${ssh_local}"/ssm-ssh-tmp.pub)
 }
 


### PR DESCRIPTION
Old Ubuntu 12 machines run OpenSSH 5.9 and does not support ssh key generation using the ed25519 algorithm. Support for this is not available until OpenSSH 6.5, which would start with Ubuntu 14. We have decided to use the RSA algorithm with a 4096 bit sized key.